### PR TITLE
[FIX][16.0] spreadsheet_oca: drop revision of empty command to avoid error for undo, redo case

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_renderer.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/bundle/spreadsheet_renderer.esm.js
@@ -65,6 +65,17 @@ export class SpreadsheetRenderer extends Component {
             dialogContent: undefined,
         });
         this.confirmDialog = this.closeDialog;
+        /**
+        * The command is empty, we have to drop all the next local revisions
+        * to avoid issues with undo/redo
+		* Same in method 'sendPendingMessage' of o_spreadsheet.js (can't add direct link to it because file is to large)
+        */
+        let revisions = [];
+        this.props.record.revisions.forEach((revision) => {
+            if (revision.commands.length > 0){
+                revisions.push(revision)
+            }
+        });
         this.spreadsheet_model = new Model(
             migrate(this.props.record.spreadsheet_raw),
             {
@@ -82,7 +93,7 @@ export class SpreadsheetRenderer extends Component {
                 mode: this.props.record.mode,
                 dataSources,
             },
-            this.props.record.revisions
+            revisions
         );
         useSubEnv({
             saveSpreadsheet: this.onSpreadsheetSaved.bind(this),


### PR DESCRIPTION
-Step to reproduce: create a spreadsheet, write something on it, undo using Ctrl + Z and then open a new google tab , open that spreadsheet again and we will get traceback
-Reason: There are still some leftover revision which have empty command -Solution: Same in method 'sendPendingMessage' of o_spreadsheet.js (can't add direct link to it because file is to large)

Video:

https://github.com/Viindoo/spreadsheet/assets/56789189/c5516586-c8f1-4d20-a0ba-3f208eda6e24

