### PR TITLE
[IMP] spreadsheet_oca: avoid using Set.intersection() for compatibility with older browsers

### DIFF
--- a/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
+++ b/spreadsheet_oca/static/src/spreadsheet/pivot_controller.esm.js
@@ -23,7 +23,9 @@ patch(
                     .concat(this.model.metaData.expandedRowGroupBys)
                     .map((el) => el.split(":")[0])
             );
-            return Boolean(colGroupBys.intersection(rowGroupBys).size);
+            return Boolean(
+                new Set([...colGroupBys].filter((item) => rowGroupBys.has(item))).size
+            );
         },
         disableSpreadsheetInsertion() {
             return (


### PR DESCRIPTION
Because Set.intersection() is only compatible with chrome browsers 122+

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection

`https://github.com/OCA/spreadsheet/pull/45`